### PR TITLE
Fix kitchen test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,7 +24,6 @@ platforms:
   - name: fedora-26
   - name: ubuntu-14.04
   - name: ubuntu-16.04
-  - name: ubuntu-17.04
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,8 +7,12 @@ long_description 'Installs/Configures nodenv'
 version '0.1.4'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
-supports 'ubuntu'
 
 issues_url 'https://github.com/afaundez/nodenv-cookbook/issues'
-
 source_url 'https://github.com/afaundez/nodenv-cookbook'
+
+supports 'ubuntu'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'amazonlinux'

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -2,8 +2,10 @@
 
 # Inspec test for recipe test::default
 
-describe package('git') do
-  it { should be_installed }
+describe command('git') do
+  it { should exist }
+  its('exit_status') { should eq 1 }
+  its('stdout') { should include('usage: git') }
 end
 
 describe file('/etc/profile.d/nodenv.sh') do


### PR DESCRIPTION
This fixes issues with test-kitchen on ubuntu-16 and fedora-26. Also, updates the cookbook supported OS list.