### PR TITLE
Install git with cookbook instead package

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,11 +18,12 @@ platforms:
       box: mvbcoding/awslinux
   - name: centos-6
   - name: centos-7
-  - name: debian-7
   - name: debian-8
   - name: debian-9
   - name: fedora-26
+  - name: ubuntu-12.04
   - name: ubuntu-14.04
+    run_list: apt::default
   - name: ubuntu-16.04
 
 suites:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove testing doc
 ### Updated
 - Add testing to readme
+- Install git with cookbook
 
 ## [0.1.4] - 2018-01-25
 ### Updated

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,6 @@ long_description 'Installs/Configures nodenv'
 version '0.1.4'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
-
 issues_url 'https://github.com/afaundez/nodenv-cookbook/issues'
 source_url 'https://github.com/afaundez/nodenv-cookbook'
 
@@ -15,4 +14,7 @@ supports 'ubuntu'
 supports 'centos'
 supports 'debian'
 supports 'fedora'
-supports 'amazonlinux'
+supports 'freebsd'
+supports 'amazon'
+
+depends 'git', '~> 8.0.0'

--- a/resources/nodenv.rb
+++ b/resources/nodenv.rb
@@ -12,7 +12,7 @@ property :nodenv_plugins, String, default: lazy { ::File.join(nodenv_root, 'plug
 action :install do
   node.run_state['root_path'] = new_resource.nodenv_root
 
-  package %w(git-core grep)
+  include_recipe 'git'
 
   git new_resource.nodenv_root do
     repository new_resource.git_url

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,5 +1,5 @@
 name 'test'
-version '0.99.0'
+version '0.1.4'
 
 depends 'nodenv'
 depends 'apt'

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,6 +1,3 @@
-
-apt_update 'update'
-
 nodenv 'vagrant' do
   versions ['8.2.1']
   action   :install

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -1,13 +1,3 @@
-# # encoding: utf-8
-
-# Inspec test for recipe test::default
-
-describe command('git') do
-  it { should exist }
-  its('exit_status') { should eq 1 }
-  its('stdout') { should include('usage: git') }
-end
-
 describe file('/etc/profile.d/nodenv.sh') do
   it { should exist }
 end


### PR DESCRIPTION
This delegates the git installation to the git cookbook, in order to avoid SO packages names