### PR TITLE
Resources can receive group property

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -9,6 +9,11 @@ transport:
 provisioner:
   name: dokken
 
+verifier:
+  name: inspec
+  inspec_tests:
+    - path: test/smoke/
+
 platforms:
 - name: amazonlinux
   driver:

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'berkshelf'
+gem 'kitchen'
+gem 'kitchen-dokken'
+gem 'kitchen-inspec'

--- a/resources/global.rb
+++ b/resources/global.rb
@@ -20,11 +20,14 @@
 #
 property :version, String, name_property: true
 property :user, String
+property :group, String, default: ''
 
 action :install do
+  nd_group = new_resource.group != '' ? new_resource.group : new_resource.user
   nodenv_command "Set global nodenv version for #{new_resource.user}" do
     version   new_resource.version
     user      new_resource.user
+    group     nd_group
     command   "nodenv global #{new_resource.version}"
     not_if    { current_global_version_correct? }
   end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,10 +1,13 @@
 property :version, String, name_property: true
 property :user, String, default: 'root'
+property :group, String, default: ''
 
 action :install do
+  nd_group = new_resource.group != '' ? new_resource.group : new_resource.user
   nodenv_command "Install node #{new_resource.version} for #{new_resource.user}" do
     version   new_resource.version
     user      new_resource.user
+    group     nd_group
     command   "nodenv install #{new_resource.version}"
     not_if    { ::File.exist? node_version_path }
   end

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -25,3 +25,15 @@ describe bash('sudo -H -u user-with-nodenv bash -c "source /etc/profile.d/nodenv
   its('stdout') { should include(user_version) }
   its('stdout') { should_not match(/system/) }
 end
+
+describe directory("/home/user-with-nodenv/.nodenv/versions/#{user_version}") do
+  it { should exist }
+  its('owner') { should eq 'user-with-nodenv' }
+  its('group') { should eq 'user-with-nodenv' }
+end
+
+describe file('/home/user-with-nodenv/.nodenv/version') do
+  it { should exist }
+  its('owner') { should eq 'user-with-nodenv' }
+  its('group') { should eq 'user-with-nodenv' }
+end


### PR DESCRIPTION
Current implementation executes bash commands with uid=`user`, gid=`root`, so installed files/directories' owner is `user` but group is `root`.
It's OK for installation for `root`, but not appropriate for non-privileged user installation.
