### PR TITLE
Fix/use user property for installing node build

### DIFF
--- a/resources/user.rb
+++ b/resources/user.rb
@@ -24,7 +24,10 @@ action :install do
     cookbook 'nodenv'
   end
 
-  node_build_plugin_install ::File.join(nodenv_plugins_path, 'node-build')
+  node_build_plugin_install ::File.join(nodenv_plugins_path, 'node-build') do
+    user new_resource.user
+    group new_resource.user
+  end
 end
 
 action_class do

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -37,3 +37,9 @@ describe file('/home/user-with-nodenv/.nodenv/version') do
   its('owner') { should eq 'user-with-nodenv' }
   its('group') { should eq 'user-with-nodenv' }
 end
+
+describe directory("/home/user-with-nodenv/.nodenv/plugins") do
+  it { should exist }
+  its('owner') { should eq 'user-with-nodenv' }
+  its('group') { should eq 'user-with-nodenv' }
+end


### PR DESCRIPTION
ref to https://github.com/afaundez/nodenv-cookbook/pull/14

A fix for the installation of the node-build plugin to use privileges when installing to unprivileged users.

There are so many supported platforms that I couldn't run all of them, but I added a test to check permissions in the plugins directory, as follows

```bash
(snip)
  Directory /home/user-with-nodenv/.nodenv/plugins
       should exist
       owner should eq "user-with-nodenv"
       group should eq "user-with-nodenv"
```