### PR TITLE
Fix deprecation error

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -8,7 +8,7 @@ transport:
 
 provisioner:
   name: dokken
-  deprecations_as_errors: false
+  deprecations_as_errors: true
   chef_license: accept-no-persist
 
 verifier:

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Alvaro Faundez'
 maintainer_email 'alvaro@faundez.net'
 license 'MIT'
 description 'Installs/Configures nodenv'
-version '1.0.3'
+version '1.0.4'
 
 issues_url 'https://github.com/afaundez/nodenv-cookbook/issues'
 source_url 'https://github.com/afaundez/nodenv-cookbook'

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -28,7 +28,7 @@ action :install do
   end
 
   node_build_plugin_install ::File.join(nodenv_plugins_path, 'node-build') do
-    user new_resource.user
+    owner new_resource.user
     group new_resource.user
   end
 end


### PR DESCRIPTION
node_build_plugin_install in resources/user.rb is called with `user`.
`user` is deprecated and fails when kitchen deprecations_as_errors: true
Updating to use the correct property name: `owner`

https://github.com/afaundez/nodenv-cookbook/issues/18